### PR TITLE
Update Maps Gesture Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] -  2018-04-07
+
+### Changed
+- Google Maps gesture handling changed to greedy for single finger map panning.
+
 ## [1.2] -  2017-08-11
 
 ### Added

--- a/src/components/MapItems.vue
+++ b/src/components/MapItems.vue
@@ -84,7 +84,9 @@ export default {
 
       var mapOptions = {
         center: {lat: 64.467506, lng: 11.495773},
-        zoom: this.config.mapConfig.zoomLow
+        zoom: this.config.mapConfig.zoomLow,
+        gestureHandling: this.mapConfig.gesture
+
         // styles: mapStyle
       }
       var mapElm = document.getElementById('funnmap')

--- a/src/components/RegisterItem.vue
+++ b/src/components/RegisterItem.vue
@@ -188,7 +188,7 @@ export default {
       var mapOptions = {
         center: pos,
         zoom: this.mapConfig.zoomBase,
-        gestureHandling: this.mapConfig.greedy
+        gestureHandling: this.mapConfig.gesture
         // styles: mapStyle
       }
       var icon = {


### PR DESCRIPTION
Google Maps gesture handling changed to greedy for single finger map panning.
